### PR TITLE
remove broken WfdCommon dependents. 

### DIFF
--- a/msm8996.mk
+++ b/msm8996.mk
@@ -390,9 +390,6 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PACKAGES += \
     libnl
 
-PRODUCT_BOOT_JARS += \
-    WfdCommon
-
 # CryptfsHW
 PRODUCT_PACKAGES += \
     vendor.qti.hardware.cryptfshw@1.0-service-qti.qsee

--- a/proprietary-files-qc.txt
+++ b/proprietary-files-qc.txt
@@ -543,7 +543,6 @@ bin/wfdservice|934817e5689fe6f8b54032902de58c203b8ec2e7
 etc/init/wfdservice.rc|311bfdd1675e56499662f39455536b75b78477bb
 etc/wfdconfig.xml|d07f6b0441c0aa8913865100239490fa8687a020
 etc/wfdconfigsink.xml|5b4a96f251fd83c2eee520d06bea2b5b159fcd36
--framework/WfdCommon.jar|3440607d29511e1a671e565a2acc4d262e38a9fb
 lib/com.qualcomm.qti.wifidisplayhal@1.0.so|93487a83a35f0fa3fe37445edd3ff22fcc52e4fc
 lib/libmmrtpdecoder.so|c4d8d4ec093a24e2d158ffe1edb408aeb83e5edb
 lib/libmmrtpencoder.so|c1d969d3600a9b9a7505e4d1f18ab3ac0f111406


### PR DESCRIPTION
FAILED to build lineageOS 18.1: out/soong/.bootstrap/bin/soong_build out/soong/build.ninja
Outputs: out/soong/build.ninja
Error: exited with code: 1
Command: out/soong/.bootstrap/bin/soong_build -t -l out/.module_paths/Android.bp.list -b out/soong -n out -d out/soong/build.ninja.d -globFile out/soong/.bootstrap/build-globs.ninja -o out/soong/build.ninja Android.bp
Output:
internal error: failed to find a dex jar path for module 'WfdCommon', note that some jars may be filtered out by module constraints.
